### PR TITLE
Introduction of .integerValue

### DIFF
--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -27,7 +27,8 @@ public protocol StructuredDataSerializer {
 public enum StructuredData {
     case nullValue
     case boolValue(Bool)
-    case numberValue(Double)
+    case doubleValue(Double)
+    case integerValue(Int)
     case stringValue(String)
     case binaryValue(Data)
     case arrayValue([StructuredData])
@@ -42,11 +43,11 @@ public enum StructuredData {
     }
 
     public static func from(_ value: Double) -> StructuredData {
-        return .numberValue(value)
+        return .doubleValue(value)
     }
 
     public static func from(_ value: Int) -> StructuredData {
-        return .numberValue(Double(value))
+        return .integerValue(value)
     }
 
     public static func from(_ value: String) -> StructuredData {
@@ -72,8 +73,15 @@ public enum StructuredData {
         return false
     }
 
-    public var isNumber: Bool {
-        if case .numberValue = self {
+    public var isDouble: Bool {
+        if case .doubleValue = self {
+            return true
+        }
+        return false
+    }
+    
+    public var isInteger: Bool {
+        if case .integerValue = self {
             return true
         }
         return false
@@ -116,11 +124,14 @@ public enum StructuredData {
     }
 
     public var int: Int? {
-        return double.flatMap({Int($0)})
+        return try? get()
     }
 
     public var uint: UInt? {
-        return double.flatMap({UInt($0)})
+        if let int = int where int >= 0 {
+            return UInt(int)
+        }
+        return nil
     }
 
     public var string: String? {
@@ -145,27 +156,22 @@ public enum StructuredData {
 
     public func get<T>() throws -> T {
         switch self {
-        case boolValue(let value as T):
+        case .boolValue(let value as T):
             return value
-
-        case numberValue(let value as T):
+        case .doubleValue(let value as T):
             return value
-
-        case stringValue(let value as T):
+        case .stringValue(let value as T):
             return value
-
+        case .integerValue(let value as T):
+            return value
         case .binaryValue(let value as T):
             return value
-
         case arrayValue(let value as T):
             return value
-
         case dictionaryValue(let value as T):
             return value
-
         default: break
         }
-
         throw Error.incompatibleType
     }
 
@@ -186,10 +192,7 @@ public enum StructuredData {
     }
 
     public func asInt() throws -> Int {
-        if let int = int {
-            return int
-        }
-        throw Error.incompatibleType
+        return try get()
     }
 
     public func asUInt() throws -> UInt {
@@ -258,29 +261,24 @@ extension StructuredData: Equatable {}
 
 public func ==(lhs: StructuredData, rhs: StructuredData) -> Bool {
     switch (lhs, rhs) {
-        case (.nullValue, .nullValue):
-            return true
-
-        case (.boolValue(let l), .boolValue(let r)) where l == r:
-            return true
-
-        case (.stringValue(let l), .stringValue(let r)) where l == r:
-            return true
-
-        case (.binaryValue(let l), .binaryValue(let r)) where l == r:
-            return true
-
-        case (.numberValue(let l), .numberValue(let r)) where l == r:
-            return true
-
-        case (.arrayValue(let l), .arrayValue(let r)) where l == r:
-            return true
-
-        case (.dictionaryValue(let l), .dictionaryValue(let r)) where l == r:
-            return true
-
-        default:
-            return false
+    case (.nullValue, .nullValue):
+        return true
+    case (.boolValue(let l), .boolValue(let r)) where l == r:
+        return true
+    case (.stringValue(let l), .stringValue(let r)) where l == r:
+        return true
+    case (.binaryValue(let l), .binaryValue(let r)) where l == r:
+        return true
+    case (.doubleValue(let l), .doubleValue(let r)) where l == r:
+        return true
+    case (.integerValue(let l), .integerValue(let r)) where l == r:
+        return true
+    case (.arrayValue(let l), .arrayValue(let r)) where l == r:
+        return true
+    case (.dictionaryValue(let l), .dictionaryValue(let r)) where l == r:
+        return true
+    default:
+        return false
     }
 }
 
@@ -298,13 +296,13 @@ extension StructuredData: BooleanLiteralConvertible {
 
 extension StructuredData: IntegerLiteralConvertible {
     public init(integerLiteral value: IntegerLiteralType) {
-        self = .numberValue(Double(value))
+        self = .integerValue(Int(value))
     }
 }
 
 extension StructuredData: FloatLiteralConvertible {
     public init(floatLiteral value: FloatLiteralType) {
-        self = .numberValue(Double(value))
+        self = .doubleValue(Double(value))
     }
 }
 
@@ -359,7 +357,8 @@ extension StructuredData: CustomStringConvertible {
             switch data {
             case .nullValue: return "null"
             case .boolValue(let b): return String(b)
-            case .numberValue(let n): return serialize(number: n)
+            case .doubleValue(let n): return serialize(number: n)
+            case .integerValue(let n): return n.description
             case .stringValue(let s): return escape(s)
             case .binaryValue(let d): return escape(d.hexadecimalDescription)
             case .arrayValue(let a): return serialize(array: a)

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -79,7 +79,7 @@ public enum StructuredData {
         }
         return false
     }
-    
+
     public var isInteger: Bool {
         if case .integerValue = self {
             return true

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import StructuredDataTestSuite
 
 XCTMain([
-    testCase(StructuredDataTests.allTests)
+    testCase(StructuredDataTests.allTests),
 ])
 
 #endif

--- a/Tests/StructuredData/StructuredDataTests.swift
+++ b/Tests/StructuredData/StructuredDataTests.swift
@@ -6,15 +6,11 @@ class StructuredDataTests: XCTestCase {
 	let dict: [String: StructuredData] = ["bool": .from(false), "double": .from(1.5)]
 
 	let boolData: StructuredData = .boolValue(true)
-	let intData: StructuredData = .numberValue(1)
-	let doubleData: StructuredData = .numberValue(1.5)
+	let intData: StructuredData = .integerValue(1)
+	let doubleData: StructuredData = .doubleValue(1.5)
 	let stringData: StructuredData = .stringValue("string")
 	lazy var arrayData: StructuredData = .arrayValue(self.array)
 	lazy var dictData: StructuredData = .dictionaryValue(self.dict)
-
-	func testReality() {
-		XCTAssert(2 + 2 == 4, "Something is severely wrong here.")
-	}
 
 	func testFrom() {
 		XCTAssertEqual(StructuredData.from(true), boolData)
@@ -27,23 +23,20 @@ class StructuredDataTests: XCTestCase {
 
 	func testCheckType() {
 		XCTAssertTrue(boolData.isBool)
-		XCTAssertTrue(intData.isNumber)
-		XCTAssertTrue(doubleData.isNumber)
+		XCTAssertTrue(intData.isInteger)
+		XCTAssertTrue(doubleData.isDouble)
 		XCTAssertTrue(stringData.isString)
 		XCTAssertTrue(arrayData.isArray)
 		XCTAssertTrue(dictData.isDictionary)
 
-		XCTAssertFalse(boolData.isNumber)
+		XCTAssertFalse(boolData.isInteger)
 		XCTAssertFalse(intData.isBool)
 	}
 
-	func testRetriveRawValue() {
+	func testRetrieveRawValue() {
 		XCTAssertEqual(boolData.bool, true)
 		XCTAssertEqual(intData.int, 1)
 		XCTAssertEqual(intData.uint, 1)
-		XCTAssertEqual(intData.double, 1)
-		XCTAssertEqual(doubleData.int, 1)
-		XCTAssertEqual(doubleData.uint, 1)
 		XCTAssertEqual(doubleData.double, 1.5)
 		XCTAssertEqual(stringData.string, "string")
 
@@ -68,11 +61,11 @@ class StructuredDataTests: XCTestCase {
 		let bool: Bool? = try? boolData.get()
 		XCTAssertEqual(bool, true)
 
-		let double: Double? = try? intData.get()
-		XCTAssertEqual(double, 1)
+		let double: Double? = try? doubleData.get()
+		XCTAssertEqual(double, 1.5)
 
 		let int: Int? = try? intData.get()
-		XCTAssertNil(int)
+		XCTAssertEqual(int, 1)
 
 		let uint: UInt? = try? intData.get()
 		XCTAssertNil(uint)
@@ -91,9 +84,6 @@ class StructuredDataTests: XCTestCase {
 		XCTAssertEqual(try? boolData.asBool(), true)
 		XCTAssertEqual(try? intData.asInt(), 1)
 		XCTAssertEqual(try? intData.asUInt(), 1)
-		XCTAssertEqual(try? intData.asDouble(), 1)
-		XCTAssertEqual(try? doubleData.asInt(), 1)
-		XCTAssertEqual(try? doubleData.asUInt(), 1)
 		XCTAssertEqual(try? doubleData.asDouble(), 1.5)
 		XCTAssertEqual(try? stringData.asString(), "string")
 
@@ -116,7 +106,7 @@ class StructuredDataTests: XCTestCase {
 
 	func testSubscriptByIndex() {
 		XCTAssertEqual(arrayData[0], .boolValue(true))
-		XCTAssertEqual(arrayData[1], .numberValue(1))
+		XCTAssertEqual(arrayData[1], .integerValue(1))
 		XCTAssertEqual(boolData[0], nil)
 
 		var array = arrayData
@@ -143,7 +133,13 @@ class StructuredDataTests: XCTestCase {
 extension StructuredDataTests {
     static var allTests: [(String, StructuredDataTests -> () throws -> Void)] {
         return [
-           ("testReality", testReality),
+           ("testFrom", testFrom),
+           ("testCheckType", testCheckType),
+           ("testRetrieveRawValue", testRetrieveRawValue),
+           ("testGet", testGet),
+           ("testAs", testAs),
+           ("testSubscriptByIndex", testSubscriptByIndex),
+           ("testSubscriptByKey", testSubscriptByKey),
         ]
     }
 }

--- a/Tests/StructuredData/StructuredDataTests.swift
+++ b/Tests/StructuredData/StructuredDataTests.swift
@@ -1,24 +1,35 @@
 import XCTest
 @testable import StructuredData
 
-class StructuredDataTests: XCTestCase {
-	let array: [StructuredData] = [.from(true), .from(1)]
-	let dict: [String: StructuredData] = ["bool": .from(false), "double": .from(1.5)]
+let boolData: StructuredData = .boolValue(true)
+let intData: StructuredData = .integerValue(1)
+let doubleData: StructuredData = .doubleValue(1.5)
+let stringData: StructuredData = .stringValue("string")
+let arrayData: StructuredData = .arrayValue([true, 1.5])
+let dictData: StructuredData = .dictionaryValue(["bool": false, "dobule": 1.5])
 
-	let boolData: StructuredData = .boolValue(true)
-	let intData: StructuredData = .integerValue(1)
-	let doubleData: StructuredData = .doubleValue(1.5)
-	let stringData: StructuredData = .stringValue("string")
-	lazy var arrayData: StructuredData = .arrayValue(self.array)
-	lazy var dictData: StructuredData = .dictionaryValue(self.dict)
+
+class StructuredDataTests: XCTestCase {
+
+	static var allTests: [(String, StructuredDataTests -> () throws -> Void)] {
+        return [
+           ("testFrom", testFrom),
+           ("testCheckType", testCheckType),
+           ("testRetrieveRawValue", testRetrieveRawValue),
+           ("testGet", testGet),
+           ("testAs", testAs),
+           ("testSubscriptByIndex", testSubscriptByIndex),
+           ("testSubscriptByKey", testSubscriptByKey),
+        ]
+    }
 
 	func testFrom() {
 		XCTAssertEqual(StructuredData.from(true), boolData)
 		XCTAssertEqual(StructuredData.from(1), intData)
 		XCTAssertEqual(StructuredData.from(1.5), doubleData)
 		XCTAssertEqual(StructuredData.from("string"), stringData)
-		XCTAssertEqual(StructuredData.from(array), arrayData)
-		XCTAssertEqual(StructuredData.from(dict), dictData)
+		XCTAssertEqual(StructuredData.from([true, 1.5]), arrayData)
+		XCTAssertEqual(StructuredData.from(["bool": false, "dobule": 1.5]), dictData)
 	}
 
 	func testCheckType() {
@@ -40,16 +51,16 @@ class StructuredDataTests: XCTestCase {
 		XCTAssertEqual(doubleData.double, 1.5)
 		XCTAssertEqual(stringData.string, "string")
 
-		let array = arrayData.array
-		XCTAssertNotNil(array)
-		if let array = array {
-			XCTAssertEqual(array, self.array)
+		let narray = arrayData.array
+		XCTAssertNotNil(narray)
+		if let narray = narray {
+			XCTAssertEqual(narray, [true, 1.5])
 		}
 
-		let dict = dictData.dictionary
-		XCTAssertNotNil(dict)
-		if let dict = dict {
-			XCTAssertEqual(dict, self.dict)
+		let ndict = dictData.dictionary
+		XCTAssertNotNil(ndict)
+		if let ndict = ndict {
+			XCTAssertEqual(ndict, ["bool": false, "dobule": 1.5])
 		}
 
 		XCTAssertNil(boolData.int)
@@ -87,16 +98,16 @@ class StructuredDataTests: XCTestCase {
 		XCTAssertEqual(try? doubleData.asDouble(), 1.5)
 		XCTAssertEqual(try? stringData.asString(), "string")
 
-		let array = try? arrayData.asArray()
-		XCTAssertNotNil(array)
-		if let array = array {
-			XCTAssertEqual(array, self.array)
+		let narray = try? arrayData.asArray()
+		XCTAssertNotNil(narray)
+		if let narray = narray {
+			XCTAssertEqual(narray, [true, 1.5])
 		}
 
-		let dict = try? dictData.asDictionary()
-		XCTAssertNotNil(dict)
-		if let dict = dict {
-			XCTAssertEqual(dict, self.dict)
+		let ndict = try? dictData.asDictionary()
+		XCTAssertNotNil(ndict)
+		if let ndict = ndict {
+			XCTAssertEqual(ndict, ["bool": false, "dobule": 1.5])
 		}
 		
 		XCTAssertNil(try? boolData.asInt())
@@ -128,18 +139,4 @@ class StructuredDataTests: XCTestCase {
 		XCTAssertEqual(dict["bool"], .from(true))
 		XCTAssertEqual(dict["string"], .from("string"))
 	}
-}
-
-extension StructuredDataTests {
-    static var allTests: [(String, StructuredDataTests -> () throws -> Void)] {
-        return [
-           ("testFrom", testFrom),
-           ("testCheckType", testCheckType),
-           ("testRetrieveRawValue", testRetrieveRawValue),
-           ("testGet", testGet),
-           ("testAs", testAs),
-           ("testSubscriptByIndex", testSubscriptByIndex),
-           ("testSubscriptByKey", testSubscriptByKey),
-        ]
-    }
 }

--- a/Tests/StructuredData/StructuredDataTests.swift
+++ b/Tests/StructuredData/StructuredDataTests.swift
@@ -6,7 +6,7 @@ let intData: StructuredData = .integerValue(1)
 let doubleData: StructuredData = .doubleValue(1.5)
 let stringData: StructuredData = .stringValue("string")
 let arrayData: StructuredData = .arrayValue([true, 1.5])
-let dictData: StructuredData = .dictionaryValue(["bool": false, "dobule": 1.5])
+let dictData: StructuredData = .dictionaryValue(["bool": false, "double": 1.5])
 
 
 class StructuredDataTests: XCTestCase {
@@ -29,7 +29,7 @@ class StructuredDataTests: XCTestCase {
 		XCTAssertEqual(StructuredData.from(1.5), doubleData)
 		XCTAssertEqual(StructuredData.from("string"), stringData)
 		XCTAssertEqual(StructuredData.from([true, 1.5]), arrayData)
-		XCTAssertEqual(StructuredData.from(["bool": false, "dobule": 1.5]), dictData)
+		XCTAssertEqual(StructuredData.from(["bool": false, "double": 1.5]), dictData)
 	}
 
 	func testCheckType() {
@@ -60,7 +60,7 @@ class StructuredDataTests: XCTestCase {
 		let ndict = dictData.dictionary
 		XCTAssertNotNil(ndict)
 		if let ndict = ndict {
-			XCTAssertEqual(ndict, ["bool": false, "dobule": 1.5])
+			XCTAssertEqual(ndict, ["bool": false, "double": 1.5])
 		}
 
 		XCTAssertNil(boolData.int)
@@ -107,7 +107,7 @@ class StructuredDataTests: XCTestCase {
 		let ndict = try? dictData.asDictionary()
 		XCTAssertNotNil(ndict)
 		if let ndict = ndict {
-			XCTAssertEqual(ndict, ["bool": false, "dobule": 1.5])
+			XCTAssertEqual(ndict, ["bool": false, "double": 1.5])
 		}
 		
 		XCTAssertNil(try? boolData.asInt())
@@ -117,7 +117,7 @@ class StructuredDataTests: XCTestCase {
 
 	func testSubscriptByIndex() {
 		XCTAssertEqual(arrayData[0], .boolValue(true))
-		XCTAssertEqual(arrayData[1], .integerValue(1))
+		XCTAssertEqual(arrayData[1], .doubleValue(1.5))
 		XCTAssertEqual(boolData[0], nil)
 
 		var array = arrayData


### PR DESCRIPTION
This PR renames `.numberValue` to `.doubleValue` and introduces `.integerValue` for native `Int` storing. My rationale is that using `Double` for both integer numbers and float numbers is inefficient.

This PR is breaking so it is scoped for the next release.
