### PR TITLE
Add StructuredDataInitializable default implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ osx_image: xcode7.3
 install:
   - eval "$(curl -sL https://raw.githubusercontent.com/Zewo/Zewo/5254525d9da56df29346fd76e99529c22034d61d/Scripts/install-swiftenv.sh)"
 script:
-  - swift build -Xlinker -rpath -Xlinker $(pwd)/.build/debug/
-  - swift build --configuration release -Xlinker -rpath -Xlinker $(pwd)/.build/release/
+  - swift build
+  - swift build --configuration release
   - swift test

--- a/Package.swift
+++ b/Package.swift
@@ -4,5 +4,6 @@ let package = Package(
     name: "StructuredData",
     dependencies: [
         .Package(url: "https://github.com/open-swift/C7.git", majorVersion: 0, minor: 9),
+        .Package(url: "https://github.com/Zewo/Reflection.git", majorVersion: 0, minor: 7)
     ]
 )

--- a/Sources/Reflection.swift
+++ b/Sources/Reflection.swift
@@ -1,0 +1,120 @@
+import Reflection
+
+extension C7.StructuredDataInitializable {
+    
+    init(structuredData: StructuredData) throws {
+        let dictionary = try structuredData.asDictionary()
+        self = try construct { property in
+            guard let initializable = property.type as? C7.StructuredDataInitializable.Type else {
+                throw StructuredDataError.notStructuredDataInitializable(property.type)
+            }
+            return try initializable.init(structuredData: dictionary[property.key] ?? .null)
+        }
+    }
+    
+}
+
+extension Optional : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        switch structuredData {
+        case .null: self = .none
+        default:
+            guard let initializable = Wrapped.self as? C7.StructuredDataInitializable.Type else {
+                throw StructuredDataError.notStructuredDataInitializable(Wrapped)
+            }
+            self = try initializable.init(structuredData: structuredData) as? Wrapped
+        }
+    }
+    
+}
+
+extension Bool : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        guard case .bool(let bool) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: Bool.self, from: try structuredData.get().dynamicType)
+        }
+        self = bool
+    }
+    
+}
+
+extension Double : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        guard case .double(let double) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: Double.self, from: try structuredData.get().dynamicType)
+        }
+        self = double
+    }
+    
+}
+
+extension Int : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        guard case .int(let int) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: Int.self, from: try structuredData.get().dynamicType)
+        }
+        self = int
+    }
+    
+}
+
+extension String : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        guard case .string(let string) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: String.self, from: try structuredData.get().dynamicType)
+        }
+        self = string
+    }
+    
+}
+
+extension Data : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        guard case .data(let data) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: Data.self, from: try structuredData.get().dynamicType)
+        }
+        self = data
+    }
+    
+}
+
+extension Array : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        guard case .array(let array) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: Array.self, from: try structuredData.get().dynamicType)
+        }
+        guard let initializable = Element.self as? C7.StructuredDataInitializable.Type else {
+            throw StructuredDataError.notStructuredDataInitializable(Element.self)
+        }
+        self = try array.map { try initializable.init(structuredData: $0) as! Element }
+    }
+    
+}
+
+extension Dictionary : C7.StructuredDataInitializable {
+    
+    public init(structuredData: StructuredData) throws {
+        guard case .dictionary(let dictionary) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: Dictionary.self, from: try structuredData.get().dynamicType)
+        }
+        guard Key.self is String.Type else {
+            throw StructuredDataError.notStructuredDataInitializable(self.dynamicType)
+        }
+        guard let initializable = Value.self as? C7.StructuredDataInitializable.Type else {
+            throw StructuredDataError.notStructuredDataInitializable(Element)
+        }
+        self = try dictionary.reduce([:]) {
+            var dictionary = $0
+            dictionary[$1.key as! Key] = try initializable.init(structuredData: $1.value) as? Value
+            return dictionary
+        }
+    }
+    
+}

--- a/Sources/Reflection.swift
+++ b/Sources/Reflection.swift
@@ -3,7 +3,9 @@ import Reflection
 extension C7.StructuredDataInitializable {
     
     init(structuredData: StructuredData) throws {
-        let dictionary = try structuredData.asDictionary()
+        guard case .dictionary(let dictionary) = structuredData else {
+            throw StructuredDataError.cannotInitialize(type: Self.self, from: try structuredData.get().dynamicType)
+        }
         self = try construct { property in
             guard let initializable = property.type as? C7.StructuredDataInitializable.Type else {
                 throw StructuredDataError.notStructuredDataInitializable(property.type)

--- a/Sources/Reflection.swift
+++ b/Sources/Reflection.swift
@@ -2,7 +2,7 @@ import Reflection
 
 extension C7.StructuredDataInitializable {
     
-    init(structuredData: StructuredData) throws {
+    public init(structuredData: StructuredData) throws {
         guard case .dictionary(let dictionary) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Self.self, from: try structuredData.get().dynamicType)
         }

--- a/Sources/Reflection.swift
+++ b/Sources/Reflection.swift
@@ -1,107 +1,114 @@
+// Reflection.swift
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Brad Hilton
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 import Reflection
 
-extension C7.StructuredDataInitializable {
-    
+extension StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .dictionary(let dictionary) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Self.self, from: try structuredData.get().dynamicType)
         }
         self = try construct { property in
-            guard let initializable = property.type as? C7.StructuredDataInitializable.Type else {
+            guard let initializable = property.type as? StructuredDataInitializable.Type else {
                 throw StructuredDataError.notStructuredDataInitializable(property.type)
             }
             return try initializable.init(structuredData: dictionary[property.key] ?? .null)
         }
     }
-    
 }
 
-extension Optional : C7.StructuredDataInitializable {
-    
+extension Optional : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         switch structuredData {
         case .null: self = .none
         default:
-            guard let initializable = Wrapped.self as? C7.StructuredDataInitializable.Type else {
-                throw StructuredDataError.notStructuredDataInitializable(Wrapped)
+            guard let initializable = Wrapped.self as? StructuredDataInitializable.Type else {
+                throw StructuredDataError.notStructuredDataInitializable(Wrapped.self)
             }
             self = try initializable.init(structuredData: structuredData) as? Wrapped
         }
     }
-    
 }
 
-extension Bool : C7.StructuredDataInitializable {
-    
+extension Bool : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .bool(let bool) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Bool.self, from: try structuredData.get().dynamicType)
         }
         self = bool
     }
-    
 }
 
-extension Double : C7.StructuredDataInitializable {
-    
+extension Double : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .double(let double) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Double.self, from: try structuredData.get().dynamicType)
         }
         self = double
     }
-    
 }
 
-extension Int : C7.StructuredDataInitializable {
-    
+extension Int : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .int(let int) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Int.self, from: try structuredData.get().dynamicType)
         }
         self = int
     }
-    
 }
 
-extension String : C7.StructuredDataInitializable {
-    
+extension String : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .string(let string) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: String.self, from: try structuredData.get().dynamicType)
         }
         self = string
     }
-    
 }
 
-extension Data : C7.StructuredDataInitializable {
-    
+extension Data : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .data(let data) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Data.self, from: try structuredData.get().dynamicType)
         }
         self = data
     }
-    
 }
 
-extension Array : C7.StructuredDataInitializable {
-    
+extension Array : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .array(let array) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Array.self, from: try structuredData.get().dynamicType)
         }
-        guard let initializable = Element.self as? C7.StructuredDataInitializable.Type else {
+        guard let initializable = Element.self as? StructuredDataInitializable.Type else {
             throw StructuredDataError.notStructuredDataInitializable(Element.self)
         }
         self = try array.map { try initializable.init(structuredData: $0) as! Element }
     }
-    
 }
 
-extension Dictionary : C7.StructuredDataInitializable {
-    
+extension Dictionary : StructuredDataInitializable {
     public init(structuredData: StructuredData) throws {
         guard case .dictionary(let dictionary) = structuredData else {
             throw StructuredDataError.cannotInitialize(type: Dictionary.self, from: try structuredData.get().dynamicType)
@@ -109,8 +116,8 @@ extension Dictionary : C7.StructuredDataInitializable {
         guard Key.self is String.Type else {
             throw StructuredDataError.notStructuredDataInitializable(self.dynamicType)
         }
-        guard let initializable = Value.self as? C7.StructuredDataInitializable.Type else {
-            throw StructuredDataError.notStructuredDataInitializable(Element)
+        guard let initializable = Value.self as? StructuredDataInitializable.Type else {
+            throw StructuredDataError.notStructuredDataInitializable(Element.self)
         }
         self = try dictionary.reduce([:]) {
             var dictionary = $0
@@ -118,5 +125,4 @@ extension Dictionary : C7.StructuredDataInitializable {
             return dictionary
         }
     }
-    
 }

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -33,9 +33,8 @@ public enum StructuredDataError: ErrorProtocol {
     case cannotInitialize(type: Any.Type, from: Any.Type)
 }
 
-protocol StructuredDataConvertible : StructuredDataInitializable, StructuredDataFallibleRepresentable {}
-
 // MARK: Parser/Serializer Protocols
+
 public protocol StructuredDataParser {
     func parse(_ data: Data) throws -> StructuredData
 }
@@ -51,6 +50,7 @@ public protocol StructuredDataSerializer {
 }
 
 // MARK: Initializers
+
 extension StructuredData {
     public init(_ value: StructuredDataRepresentable) {
         self = value.structuredData
@@ -120,6 +120,7 @@ extension StructuredData {
 }
 
 // MARK: Type Inference
+
 extension StructuredData {
     public static func infer<T: StructuredDataRepresentable>(_ value: T?) -> StructuredData {
         return StructuredData(value)
@@ -171,6 +172,7 @@ extension StructuredData {
 }
 
 // MARK: Getters/Setters
+
 extension StructuredData {
     public func get<T>() throws -> T {
         switch self {
@@ -233,6 +235,7 @@ extension StructuredData {
 }
 
 // MARK: Subscripts
+
 extension StructuredData {
     public subscript(index: Int) -> StructuredData? {
         get {
@@ -272,6 +275,7 @@ extension StructuredData {
 }
 
 // MARK: is<Type>
+
 extension StructuredData {
     public var isBool: Bool {
         if case .bool = self {
@@ -324,6 +328,7 @@ extension StructuredData {
 }
 
 // MARK: <type>Value
+
 extension StructuredData {
     public var boolValue: Bool? {
         return try? get()
@@ -355,6 +360,7 @@ extension StructuredData {
 }
 
 // MARK: as<type>
+
 extension StructuredData {
     public func asBool(converting: Bool = false) throws -> Bool {
         guard converting else {
@@ -545,6 +551,7 @@ extension StructuredData {
 }
 
 // MARK: Equatable
+
 extension StructuredData: Equatable {}
 
 public func ==(lhs: StructuredData, rhs: StructuredData) -> Bool {
@@ -562,6 +569,7 @@ public func ==(lhs: StructuredData, rhs: StructuredData) -> Bool {
 }
 
 // MARK: Literal Convertibles
+
 extension StructuredData: NilLiteralConvertible {
     public init(nilLiteral value: Void) {
         self = .null
@@ -629,6 +637,7 @@ extension StructuredData: DictionaryLiteralConvertible {
 }
 
 // MARK: CustomStringConvertible
+
 extension StructuredData: CustomStringConvertible {
     public var description: String {
         var indentLevel = 0

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -2,6 +2,8 @@
 
 public enum StructuredDataError: ErrorProtocol {
     case incompatibleType
+    case notStructuredDataInitializable(Any.Type)
+    case cannotInitialize(type: Any.Type, from: Any.Type)
 }
 
 // MARK: Convertible Protocols

--- a/Sources/StructuredData.swift
+++ b/Sources/StructuredData.swift
@@ -28,6 +28,7 @@ public enum StructuredDataError: ErrorProtocol {
     case incompatibleType
     case notStructuredDataInitializable(Any.Type)
     case notStructuredDataRepresentable(Any.Type)
+    case notStructuredDataDictionaryKeyInitializable(Any.Type)
     case notStructuredDataDictionaryKeyRepresentable(Any.Type)
     case cannotInitialize(type: Any.Type, from: Any.Type)
 }

--- a/Sources/StructuredDataInitializable.swift
+++ b/Sources/StructuredDataInitializable.swift
@@ -1,8 +1,8 @@
-// Reflection.swift
+// StructuredData.swift
 //
 // The MIT License (MIT)
 //
-// Copyright (c) 2016 Brad Hilton
+// Copyright (c) 2016 Zewo
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/Sources/StructuredDataRepresentable.swift
+++ b/Sources/StructuredDataRepresentable.swift
@@ -1,0 +1,173 @@
+// StructuredData.swift
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Zewo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Reflection
+
+public protocol StructuredDataFallibleRepresentable {
+    func asStructuredData() throws -> StructuredData
+}
+
+public protocol StructuredDataRepresentable: StructuredDataFallibleRepresentable {
+    var structuredData: StructuredData { get }
+}
+
+extension StructuredDataRepresentable {
+    public func asStructuredData() throws -> StructuredData {
+        return structuredData
+    }
+}
+
+extension StructuredDataFallibleRepresentable {
+    func asStructuredData() throws -> StructuredData {
+        var dictionary = [String : StructuredData]()
+        for property in try properties(self) {
+            guard let representable = property.value as? StructuredDataFallibleRepresentable else {
+                throw StructuredDataError.notStructuredDataRepresentable(property.value.dynamicType)
+            }
+            dictionary[property.key] = try representable.asStructuredData()
+        }
+        return .dictionary(dictionary)
+    }
+}
+
+extension Bool: StructuredDataRepresentable {
+    public var structuredData: StructuredData {
+        return .bool(self)
+    }
+}
+
+extension Double: StructuredDataRepresentable {
+    public var structuredData: StructuredData {
+        return .double(self)
+    }
+}
+
+extension Int: StructuredDataRepresentable {
+    public var structuredData: StructuredData {
+        return .int(self)
+    }
+}
+
+extension String: StructuredDataRepresentable {
+    public var structuredData: StructuredData {
+        return .string(self)
+    }
+}
+
+extension Data: StructuredDataRepresentable {
+    public var structuredData: StructuredData {
+        return .data(self)
+    }
+}
+
+extension Optional where Wrapped: StructuredDataRepresentable {
+    public var structuredData: StructuredData {
+        switch self {
+        case .some(let wrapped): return wrapped.structuredData
+        case .none: return .null
+        }
+    }
+}
+
+extension Array where Element: StructuredDataRepresentable {
+    public var structuredDataArray: [StructuredData] {
+        return self.map({$0.structuredData})
+    }
+    
+    public var structuredData: StructuredData {
+        return .array(structuredDataArray)
+    }
+}
+
+public protocol StructuredDataDictionaryKeyRepresentable {
+    var structuredDataDictionaryKey: String { get }
+}
+
+extension String: StructuredDataDictionaryKeyRepresentable {
+    public var structuredDataDictionaryKey: String {
+        return self
+    }
+}
+
+extension Dictionary where Key: StructuredDataDictionaryKeyRepresentable, Value: StructuredDataRepresentable {
+    public var structuredDataDictionary: [String: StructuredData] {
+        var dictionary: [String: StructuredData] = [:]
+        
+        for (key, value) in self.map({($0.0.structuredDataDictionaryKey, $0.1.structuredData)}) {
+            dictionary[key] = value
+        }
+        
+        return dictionary
+    }
+    
+    public var structuredData: StructuredData {
+        return .dictionary(structuredDataDictionary)
+    }
+}
+
+// MARK: StructuredDataFallibleRepresentable
+
+extension Optional : StructuredDataFallibleRepresentable {
+    public func asStructuredData() throws -> StructuredData {
+        if case .some(let wrapped) = self, let representable = wrapped as? StructuredDataFallibleRepresentable {
+            return try representable.asStructuredData()
+        } else if Wrapped.self is StructuredDataFallibleRepresentable.Type {
+            return .null
+        }
+        throw StructuredDataError.notStructuredDataRepresentable(Wrapped.self)
+    }
+}
+
+extension Array : StructuredDataFallibleRepresentable {
+    public func asStructuredData() throws -> StructuredData {
+        var array: [StructuredData] = []
+        
+        for element in self {
+            guard let representable = element as? StructuredDataFallibleRepresentable else {
+                throw StructuredDataError.notStructuredDataRepresentable(Element.self)
+            }
+            array.append(try representable.asStructuredData())
+        }
+        
+        return .array(array)
+    }
+}
+
+extension Dictionary : StructuredDataFallibleRepresentable {
+    public func asStructuredData() throws -> StructuredData {
+        var dictionary: [String: StructuredData] = [:]
+        
+        for (key, value) in self {
+            guard let representable = value as? StructuredDataFallibleRepresentable else {
+                throw StructuredDataError.notStructuredDataRepresentable(Value.self)
+            }
+            guard let key = key as? StructuredDataDictionaryKeyRepresentable else {
+                throw StructuredDataError.notStructuredDataDictionaryKeyRepresentable(Key.self)
+            }
+            dictionary[key.structuredDataDictionaryKey] = try representable.asStructuredData()
+        }
+        
+        return .dictionary(dictionary)
+    }
+}

--- a/Sources/StructuredDataRepresentable.swift
+++ b/Sources/StructuredDataRepresentable.swift
@@ -40,8 +40,9 @@ extension StructuredDataRepresentable {
 
 extension StructuredDataFallibleRepresentable {
     func asStructuredData() throws -> StructuredData {
-        var dictionary = [String : StructuredData]()
-        for property in try properties(self) {
+        let properties = try Reflection.properties(self)
+        var dictionary = [String : StructuredData](minimumCapacity: properties.count)
+        for property in properties {
             guard let representable = property.value as? StructuredDataFallibleRepresentable else {
                 throw StructuredDataError.notStructuredDataRepresentable(property.value.dynamicType)
             }
@@ -142,22 +143,20 @@ extension Optional : StructuredDataFallibleRepresentable {
 extension Array : StructuredDataFallibleRepresentable {
     public func asStructuredData() throws -> StructuredData {
         var array: [StructuredData] = []
-        
+        array.reserveCapacity(count)
         for element in self {
             guard let representable = element as? StructuredDataFallibleRepresentable else {
                 throw StructuredDataError.notStructuredDataRepresentable(Element.self)
             }
             array.append(try representable.asStructuredData())
         }
-        
         return .array(array)
     }
 }
 
 extension Dictionary : StructuredDataFallibleRepresentable {
     public func asStructuredData() throws -> StructuredData {
-        var dictionary: [String: StructuredData] = [:]
-        
+        var dictionary = [String: StructuredData](minimumCapacity: count)
         for (key, value) in self {
             guard let representable = value as? StructuredDataFallibleRepresentable else {
                 throw StructuredDataError.notStructuredDataRepresentable(Value.self)
@@ -167,7 +166,6 @@ extension Dictionary : StructuredDataFallibleRepresentable {
             }
             dictionary[key.structuredDataDictionaryKey] = try representable.asStructuredData()
         }
-        
         return .dictionary(dictionary)
     }
 }

--- a/Sources/StructuredDataRepresentable.swift
+++ b/Sources/StructuredDataRepresentable.swift
@@ -24,22 +24,8 @@
 
 import Reflection
 
-public protocol StructuredDataFallibleRepresentable {
-    func asStructuredData() throws -> StructuredData
-}
-
-public protocol StructuredDataRepresentable: StructuredDataFallibleRepresentable {
-    var structuredData: StructuredData { get }
-}
-
-extension StructuredDataRepresentable {
-    public func asStructuredData() throws -> StructuredData {
-        return structuredData
-    }
-}
-
 extension StructuredDataFallibleRepresentable {
-    func asStructuredData() throws -> StructuredData {
+    public func asStructuredData() throws -> StructuredData {
         let properties = try Reflection.properties(self)
         var dictionary = [String : StructuredData](minimumCapacity: properties.count)
         for property in properties {

--- a/Tests/StructuredData/StructuredDataTests.swift
+++ b/Tests/StructuredData/StructuredDataTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import StructuredData
+import Reflection
 
 let boolData: StructuredData = true
 let intData: StructuredData = 1
@@ -265,15 +266,17 @@ class StructuredDataTests: XCTestCase {
             XCTAssert(object == expected)
             let representation = try object.asStructuredData()
             XCTAssert(representation == structuredData)
-//            XCTAssert(object.a == expected.a)
-//            XCTAssert(object.b == expected.b)
-//            XCTAssert(object.c == expected.c)
-//            XCTAssert(object.d == expected.d)
-//            XCTAssert(object.e == expected.e)
-//            XCTAssert(object.f == expected.f)
-//            XCTAssert(object.h == expected.h)
         } catch {
             XCTFail(String(error))
+        }
+        
+        do {
+            let _ = try Object(structuredData: .dictionary([:]))
+            XCTFail()
+        } catch Reflection.Error.requiredValueMissing(key: let key) {
+            XCTAssert(key == "b")
+        } catch {
+            XCTFail()
         }
     }
     

--- a/Tests/StructuredData/StructuredDataTests.swift
+++ b/Tests/StructuredData/StructuredDataTests.swift
@@ -9,6 +9,28 @@ let arrayData: StructuredData = [true, 1.5]
 let dictData: StructuredData = ["bool": false, "double": 1.5]
 let nullData: StructuredData = nil
 
+struct Object : StructuredDataConvertible, Equatable {
+    let a: Int?
+    let b: Bool
+    let c: Double
+    let d: Int
+    let e: String
+    let f: Data
+    let g: [Int]
+    let h: [String: Int]
+}
+
+func ==(lhs: Object, rhs: Object) -> Bool {
+    return lhs.a == rhs.a &&
+        lhs.b == rhs.b &&
+        lhs.c == rhs.c &&
+        lhs.d == rhs.d &&
+        lhs.e == rhs.e &&
+        lhs.f == rhs.f &&
+        lhs.g == rhs.g &&
+        lhs.h == rhs.h
+}
+
 class StructuredDataTests: XCTestCase {
 	func testFrom() {
 		XCTAssertEqual(StructuredData.infer(true), boolData)
@@ -217,17 +239,6 @@ class StructuredDataTests: XCTestCase {
     }
     
     func testReflection() {
-        struct Object : C7.StructuredDataInitializable {
-            let a: Int?
-            let b: Bool
-            let c: Double
-            let d: Int
-            let e: String
-            let f: Data
-            let g: [Int]
-            let h: [String: Int]
-        }
-        
         let a: Int? = nil
         let b = true
         let c = 1.23
@@ -251,13 +262,16 @@ class StructuredDataTests: XCTestCase {
         let expected = Object(a: a, b: b, c: c, d: d, e: e, f: f, g: g, h: h)
         do {
             let object = try Object(structuredData: structuredData)
-            XCTAssert(object.a == expected.a)
-            XCTAssert(object.b == expected.b)
-            XCTAssert(object.c == expected.c)
-            XCTAssert(object.d == expected.d)
-            XCTAssert(object.e == expected.e)
-            XCTAssert(object.f == expected.f)
-            XCTAssert(object.h == expected.h)
+            XCTAssert(object == expected)
+            let representation = try object.asStructuredData()
+            XCTAssert(representation == structuredData)
+//            XCTAssert(object.a == expected.a)
+//            XCTAssert(object.b == expected.b)
+//            XCTAssert(object.c == expected.c)
+//            XCTAssert(object.d == expected.d)
+//            XCTAssert(object.e == expected.e)
+//            XCTAssert(object.f == expected.f)
+//            XCTAssert(object.h == expected.h)
         } catch {
             XCTFail(String(error))
         }

--- a/Tests/StructuredData/StructuredDataTests.swift
+++ b/Tests/StructuredData/StructuredDataTests.swift
@@ -215,6 +215,54 @@ class StructuredDataTests: XCTestCase {
         XCTAssertEqual(dict["dictionary"], .dictionary(["foo": .string("bar")]))
         XCTAssertEqual(dict["dictionaryOfOptional"], .dictionary(["foo": .null]))
     }
+    
+    func testReflection() {
+        struct Object : C7.StructuredDataInitializable {
+            let a: Int?
+            let b: Bool
+            let c: Double
+            let d: Int
+            let e: String
+            let f: Data
+            let g: [Int]
+            let h: [String: Int]
+        }
+        
+        let a: Int? = nil
+        let b = true
+        let c = 1.23
+        let d = 12
+        let e = "Hello"
+        let f = Data()
+        let g = [0, 1, 2]
+        let h = ["x": 1, "y": 2, "z": 3]
+        
+        let structuredData: StructuredData = [
+             "a": .infer(a),
+             "b": .infer(b),
+             "c": .infer(c),
+             "d": .infer(d),
+             "e": .infer(e),
+             "f": .infer(f),
+             "g": .infer(g),
+             "h": .infer(h),
+        ]
+        
+        let expected = Object(a: a, b: b, c: c, d: d, e: e, f: f, g: g, h: h)
+        do {
+            let object = try Object(structuredData: structuredData)
+            XCTAssert(object.a == expected.a)
+            XCTAssert(object.b == expected.b)
+            XCTAssert(object.c == expected.c)
+            XCTAssert(object.d == expected.d)
+            XCTAssert(object.e == expected.e)
+            XCTAssert(object.f == expected.f)
+            XCTAssert(object.h == expected.h)
+        } catch {
+            XCTFail(String(error))
+        }
+    }
+    
 }
 
 extension StructuredDataTests {


### PR DESCRIPTION
This pull request adds a basic default implementation for `StructuredDataInitializable` using `Reflection`. It also adds `StructuredDataInitializable` implementations for `Optional`, `Bool`, `Double`, `Int`, `String`, `Data`, `Array` and `Dictionary`.
